### PR TITLE
Add name to package to sync package-json writes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,10 @@
 {
-  "name": "Koders Bot",
+  "name": "koders-bot",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
+      "name": "koders-bot",
       "dependencies": {
         "@sapphire/stopwatch": "^1.5.0",
         "discord.js": "^14.11.0",

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "koders-bot",
   "dependencies": {
     "@sapphire/stopwatch": "^1.5.0",
     "discord.js": "^14.11.0",


### PR DESCRIPTION
Adding a name to the package.json file allows users to install dependencies from the package.json in different environments or with different directory names without prompting a line update in package-lock.json. The name is ultimately unimportant, this one is just in line with JS package conventions.